### PR TITLE
fix flaky test

### DIFF
--- a/service/configuration/src/test/java/com/alibaba/citrus/service/configuration/PropertyPlaceholderTests.java
+++ b/service/configuration/src/test/java/com/alibaba/citrus/service/configuration/PropertyPlaceholderTests.java
@@ -37,6 +37,9 @@ public class PropertyPlaceholderTests {
 
     @Test
     public void defaultValue() {
+        // initialization
+        System.clearProperty("productionMode");
+        
         factory = new XmlApplicationContext(new FileSystemResource(new File(srcdir, "property-placeholder.xml")));
         conf = (Configuration) factory.getBean("simpleConfiguration");
 

--- a/service/configuration/src/test/java/com/alibaba/citrus/service/configuration/PropertyPlaceholderTests.java
+++ b/service/configuration/src/test/java/com/alibaba/citrus/service/configuration/PropertyPlaceholderTests.java
@@ -37,9 +37,6 @@ public class PropertyPlaceholderTests {
 
     @Test
     public void defaultValue() {
-        // initialization
-        System.clearProperty("productionMode");
-        
         factory = new XmlApplicationContext(new FileSystemResource(new File(srcdir, "property-placeholder.xml")));
         conf = (Configuration) factory.getBean("simpleConfiguration");
 
@@ -49,13 +46,22 @@ public class PropertyPlaceholderTests {
 
     @Test
     public void systemPropertyValue() {
-        System.setProperty("productionMode", "true");
+        String initialValue = System.getProperty("productionMode");
+        try{
+            System.setProperty("productionMode", "true");    
 
-        factory = new XmlApplicationContext(new FileSystemResource(new File(srcdir, "property-placeholder.xml")));
-        conf = (Configuration) factory.getBean("simpleConfiguration");
+            factory = new XmlApplicationContext(new FileSystemResource(new File(srcdir, "property-placeholder.xml")));
+            conf = (Configuration) factory.getBean("simpleConfiguration");
 
-        // ${productionMode:false}
-        assertEquals(true, conf.isProductionMode());
+            // ${productionMode:false}
+            assertEquals(true, conf.isProductionMode());
+        } finally{
+            if(initialValue!=null){
+                System.setProperty("productionMode", "true");
+            }else{
+                System.clearProperty("productionMode");
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
When using NonDex to run the test `mvn -pl service/configuration edu.illinois:nondex-maven-plugin:1.1.2:nondex -DnondexRuns=100 -Dtest=com.alibaba.citrus.service.configuration.PropertyPlaceholderTests -Drat.skip`, sometimes it would occured error that error message is `PropertyPlaceholderTests.defaultValue:44 expected:<false> but was:<true>`.
However, when run NonDex on  test method #defaultValue itself rather than whole class `mvn -pl service/configuration edu.illinois:nondex-maven-plugin:1.1.2:nondex -DnondexRuns=100 -Dtest=com.alibaba.citrus.service.configuration.PropertyPlaceholderTests#defaultValue -Drat.skip`, it would not occur any error.

It is an OD flaky test. The problem is test method #systemPropertyValue changes System properties, when the execution order of tests is different, test method #defaultValue may be affected, resulting in an error occurring.

How to fix this test?
I decided to restore System properties after the test finished. This way can better isolate tests to avoid test order dependency.